### PR TITLE
CD - Push release to github releases on tags to master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,26 +2,6 @@
 #
 # Check https://circleci.com/docs/2.0/language-javascript/ for more details
 #
-aliases:
-  # Workflow filters
-  - &filter-not-release-or-master
-    tags:
-      ignore: /^v[0-9]+(\.[0-9]+){2}(-.+|[^-.]*)$/
-    branches:
-      ignore:
-        - master
-  - &filter-only-master
-    branches:
-      only: master
-  - &filter-circleci-testing
-    branches:
-      only: feature/circleci
-  - &filter-only-tagged-commits-on-master
-    branches:
-      only: master
-    tags:
-      only: /(?<=^[Vv]|^)(?:(?<major>(?:0|[1-9](?:(?:0|[1-9])+)*))[.](?<minor>(?:0|[1-9](?:(?:0|[1-9])+)*))[.](?<patch>(?:0|[1-9](?:(?:0|[1-9])+)*))(?:-(?<prerelease>(?:(?:(?:[A-Za-z]|-)(?:(?:(?:0|[1-9])|(?:[A-Za-z]|-))+)?|(?:(?:(?:0|[1-9])|(?:[A-Za-z]|-))+)(?:[A-Za-z]|-)(?:(?:(?:0|[1-9])|(?:[A-Za-z]|-))+)?)|(?:0|[1-9](?:(?:0|[1-9])+)*))(?:[.](?:(?:(?:[A-Za-z]|-)(?:(?:(?:0|[1-9])|(?:[A-Za-z]|-))+)?|(?:(?:(?:0|[1-9])|(?:[A-Za-z]|-))+)(?:[A-Za-z]|-)(?:(?:(?:0|[1-9])|(?:[A-Za-z]|-))+)?)|(?:0|[1-9](?:(?:0|[1-9])+)*)))*))?(?:[+](?<build>(?:(?:(?:[A-Za-z]|-)(?:(?:(?:0|[1-9])|(?:[A-Za-z]|-))+)?|(?:(?:(?:0|[1-9])|(?:[A-Za-z]|-))+)(?:[A-Za-z]|-)(?:(?:(?:0|[1-9])|(?:[A-Za-z]|-))+)?)|(?:(?:0|[1-9])+))(?:[.](?:(?:(?:[A-Za-z]|-)(?:(?:(?:0|[1-9])|(?:[A-Za-z]|-))+)?|(?:(?:(?:0|[1-9])|(?:[A-Za-z]|-))+)(?:[A-Za-z]|-)(?:(?:(?:0|[1-9])|(?:[A-Za-z]|-))+)?)|(?:(?:0|[1-9])+)))*))?)$/
-
 version: 2
 jobs:
   build:
@@ -36,6 +16,11 @@ jobs:
           # fallback to using the latest cache if no exact match is found
           - dependency-cache-
       - run:
+          name: Setup Environment Variables
+          command: |
+            echo "export GIT_SHA1=$(echo ${CIRCLE_SHA1} | cut -c -7)" >> $BASH_ENV
+            source $BASH_ENV
+      - run:
           name: yarn install
           command: 'yarn install --pure-lockfile --no-progress'
       - save_cache:
@@ -46,29 +31,51 @@ jobs:
       - run: yarn test
       - run:
           name: Create directories for Artifacts
-          command: mkdir -p ~/artifacts/scalyr_plugin/
+          command: mkdir -p ~/artifacts/scalyr_plugin/target/
       - run: 
           name: Build artifacts
           command: |
             yarn build
-            cp -rf dist/ /home/circleci/artifacts/ 
+            cp -rf dist/ ~/artifacts/scalyr_plugin/
+            echo Plugin git sha is ${GIT_SHA1}
+            cd ~/artifacts/scalyr_plugin/ && tar -czvf scalyr_grafana_plugin_${GIT_SHA1}.tar.gz dist/ && mv scalyr_grafana_plugin_${GIT_SHA1}.tar.gz target/
+      - persist_to_workspace:
+          root: ~/artifacts/scalyr_plugin/target/
+          paths:
+            - scalyr_grafana_plugin_*.tar.gz
       - store_artifacts:
-          path: ~/artifacts
-          destination: dist
+          path: ~/artifacts/scalyr_plugin/target/
+          destination: scalyr_grafana_plugin
   
-  deploy-to-github-release:
+  deploy-to-github-releases:
     docker: 
-      - image: circleci/golang:1.8
-    requires:
-      - build
-    filters:
-      - filter-only-tagged-commits-on-masters
-      - filter-circleci-testing
+      - image: circleci/golang:1.12
     steps:
+      - attach_workspace:
+          at: ~/artifacts/scalyr_plugin/
       - run:
           name: "Publish Release on GitHub"
           command: |
             go get github.com/tcnksm/ghr
             VERSION=${CIRCLE_TAG}
-            ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -delete ${VERSION} ./artifacts/
-            
+            echo Releasing version $VERSION
+            ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -delete ${VERSION} /home/circleci/artifacts/scalyr_plugin/
+
+workflows:
+  version: 2
+  build-and-deploy:
+    jobs:
+      - build:
+          filters:
+            tags:
+              only: /.*/
+
+      - deploy-to-github-releases:
+          requires:
+            - build
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              # See https://discuss.circleci.com/t/filter-job-by-tag-not-working-regexp-possibly-unsupported/28484
+              only: /^(\d|[1-9]\d*)\.(\d|[1-9]\d*)\.(\d|[1-9]\d*)(-(0|[1-9A-Za-z-][0-9A-Za-z-]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*)(\.(0|[1-9A-Za-z-][0-9A-Za-z-]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*))*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,12 @@ aliases:
   - &filter-only-master
     branches:
       only: master
+  
+  - &filter-only-tagged-commits-on-master
+    branches:
+      only: master
+    tags:
+      only: /(?<=^[Vv]|^)(?:(?<major>(?:0|[1-9](?:(?:0|[1-9])+)*))[.](?<minor>(?:0|[1-9](?:(?:0|[1-9])+)*))[.](?<patch>(?:0|[1-9](?:(?:0|[1-9])+)*))(?:-(?<prerelease>(?:(?:(?:[A-Za-z]|-)(?:(?:(?:0|[1-9])|(?:[A-Za-z]|-))+)?|(?:(?:(?:0|[1-9])|(?:[A-Za-z]|-))+)(?:[A-Za-z]|-)(?:(?:(?:0|[1-9])|(?:[A-Za-z]|-))+)?)|(?:0|[1-9](?:(?:0|[1-9])+)*))(?:[.](?:(?:(?:[A-Za-z]|-)(?:(?:(?:0|[1-9])|(?:[A-Za-z]|-))+)?|(?:(?:(?:0|[1-9])|(?:[A-Za-z]|-))+)(?:[A-Za-z]|-)(?:(?:(?:0|[1-9])|(?:[A-Za-z]|-))+)?)|(?:0|[1-9](?:(?:0|[1-9])+)*)))*))?(?:[+](?<build>(?:(?:(?:[A-Za-z]|-)(?:(?:(?:0|[1-9])|(?:[A-Za-z]|-))+)?|(?:(?:(?:0|[1-9])|(?:[A-Za-z]|-))+)(?:[A-Za-z]|-)(?:(?:(?:0|[1-9])|(?:[A-Za-z]|-))+)?)|(?:(?:0|[1-9])+))(?:[.](?:(?:(?:[A-Za-z]|-)(?:(?:(?:0|[1-9])|(?:[A-Za-z]|-))+)?|(?:(?:(?:0|[1-9])|(?:[A-Za-z]|-))+)(?:[A-Za-z]|-)(?:(?:(?:0|[1-9])|(?:[A-Za-z]|-))+)?)|(?:(?:0|[1-9])+)))*))?)$/
 
 version: 2
 jobs:
@@ -35,6 +41,24 @@ jobs:
             - node_modules
           key: dependency-cache-{{ checksum "yarn.lock" }}
       - run: yarn lint
+      - run: yarn test
       - run: yarn build
-
-# TODO: Ship dist/ folder to github releases and tag them
+      - store_artifacts:
+          path: ~/artifacts
+          destination: dist
+  
+  deploy-to-github-release:
+    docker: 
+      - image: circleci/golang:1.8
+    requires:
+      - build
+    filters:
+      - filter-only-tagged-commits-on-masters
+    steps:
+      - run:
+          name: "Publish Release on GitHub"
+          command: |
+            go get github.com/tcnksm/ghr
+            VERSION=$(my-binary --version)
+            ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -delete ${VERSION} ./artifacts/dist/
+            

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,14 @@ jobs:
           key: dependency-cache-{{ checksum "yarn.lock" }}
       - run: yarn lint
       - run: yarn test
-      - run: yarn build
+      - run:
+          name: Create directories for Artifacts
+          command: mkdir -p ~/artifacts/scalyr_plugin/
+      - run: 
+          name: Build artifacts
+          command: |
+            yarn build
+            cp -rf dist/ /home/circleci/artifacts/
       - store_artifacts:
           path: ~/artifacts
           destination: dist
@@ -60,5 +67,5 @@ jobs:
           command: |
             go get github.com/tcnksm/ghr
             VERSION=$(my-binary --version)
-            ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -delete ${VERSION} ./artifacts/dist/
+            ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -delete ${VERSION} ./artifacts/
             

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,9 @@ aliases:
   - &filter-only-master
     branches:
       only: master
-  
+  - &filter-circleci-testing
+    branches:
+      only: feature/circleci
   - &filter-only-tagged-commits-on-master
     branches:
       only: master
@@ -49,7 +51,7 @@ jobs:
           name: Build artifacts
           command: |
             yarn build
-            cp -rf dist/ /home/circleci/artifacts/
+            cp -rf dist/ /home/circleci/artifacts/ 
       - store_artifacts:
           path: ~/artifacts
           destination: dist
@@ -61,11 +63,12 @@ jobs:
       - build
     filters:
       - filter-only-tagged-commits-on-masters
+      - filter-circleci-testing
     steps:
       - run:
           name: "Publish Release on GitHub"
           command: |
             go get github.com/tcnksm/ghr
-            VERSION=$(my-binary --version)
+            VERSION=${CIRCLE_TAG}
             ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -delete ${VERSION} ./artifacts/
             

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## In Development
+
+## 1.0.0
+
+Initial release

--- a/HOW_TO_CONTRIBUTE.md
+++ b/HOW_TO_CONTRIBUTE.md
@@ -9,6 +9,9 @@ We welcome and appreciate contributions of any kind (code, tests, documentation,
     and use appropriate labels to indicate the kind of issue.
 * Please fork this repo and create a branch to make your changes
 * Please include the issues you are fixing in the commits
+* Please add an entry in [CHANGELOG.md](./CHANGELOG.md) in `In Development` section along with 
+  github issue number and author information. For example:
+  `Power queries now support blah (#1234) (Alice Wonderland)`
 
 ## Plugin development
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,17 @@
+# Maintainers Documentation
+
+## Release checklist
+
+* Please make sure CHANGELOG reflects the new version to be released
+  (Usually, that's changing the `In Development` items to be reflected under
+   new version and leaving `In Development` empty)
+* Set the new version to be released in plugin.json and package.json
+* Please push a tag using git commands
+
+    ```bash
+    git tag -a 0.1.0 -m "0.1.0 - Shiny new features and bug fixes"
+    git push upstream 0.1.0
+    ```
+
+* Circle CI builds the tag and ships to github releases
+* Please ensure the released tar.gz contains the `dist` folder


### PR DESCRIPTION
closes: https://github.com/scalyr/scalyr-grafana-datasource-plugin/issues/18

Used my fork to test: https://app.circleci.com/github/lakshmi-kannan/scalyr-grafana-datasource-plugin/pipelines

TODO:

* [x] Add documentation about how to release? 
~* [ ] Do a 1.0.0 release to github release~ [It's better to do this after PR is merged -  https://github.com/scalyr/scalyr-grafana-datasource-plugin/issues/33]
~* [ ] Remove dist/ folder from source control~ I have second thoughts about this. Before we do this, we have to figure out how to release current master as release
~* [ ] Update documentation for people to get plugin from github releases~ https://github.com/scalyr/scalyr-grafana-datasource-plugin/issues/32
~* [ ] Validate that the released plugin does work in Grafana install~ https://github.com/scalyr/scalyr-grafana-datasource-plugin/issues/33 