### PR TITLE
Untested circleci build changes to make a zipped artifact

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,10 +49,12 @@ jobs:
             cp -rf dist/ ~/artifacts/scalyr_plugin/
             echo Plugin git sha is ${GIT_SHA1}
             cd ~/artifacts/scalyr_plugin/ && tar -czvf scalyr_grafana_plugin_${GIT_SHA1}.tar.gz dist/ && mv scalyr_grafana_plugin_${GIT_SHA1}.tar.gz target/
+            zip -r scalyr_grafana_plugin_${GIT_SHA1}.zip dist/ && mv scalyr_grafana_plugin_${GIT_SHA1}.zip target/
       - persist_to_workspace:
           root: ~/artifacts/scalyr_plugin/target/
           paths:
             - scalyr_grafana_plugin_*.tar.gz
+            - scalyr_grafana_plugin_*.zip
       - store_artifacts:
           path: ~/artifacts/scalyr_plugin/target/
           destination: scalyr_grafana_plugin


### PR DESCRIPTION
We need to create zipped artifacts for Grafana datasource releases, and this was the few minutes of work I managed ages ago before getting distracted by something else. Still needs testing to confirm this actually publishes a .zip, and that the .zip it publishes can be installed.
Would also need to update the README to make the zip the default way to install it, if I understand the future changes Grafana is planning correctly.