### PR TITLE
CT-500: Fix table representation of Power Queries

### DIFF
--- a/src/datasource.js
+++ b/src/datasource.js
@@ -350,17 +350,8 @@ export class GenericDatasource {
     const query = this.createPowerQuery(target.filter, options.range.from.valueOf(), options.range.to.valueOf(), options);
     return this.backendSrv.datasourceRequest(query).then( (response) => {
       const data = response && response.data;
-      return this.transformPowerQueryData(data);
+      return this.transformPowerQueryDataToTable(data);
     });
-  }
-
-  /**
-   * Transform power query data based on the visualization type
-   * @param data data returned by the power query API
-   * @returns {{data: Object[]}} transformed data that can be used by Grafana
-   */
-  transformPowerQueryData(data, visualizationType) {
-    return this.transformPowerQueryDataToTable(data);
   }
 
   /**

--- a/src/datasource.js
+++ b/src/datasource.js
@@ -55,8 +55,7 @@ export class GenericDatasource {
 
     if (queryType === this.queryTypes.POWER_QUERY) {
       if (options.targets.length === 1) {
-        const panelType = options.targets[0].panelType;
-        return this.performPowerQuery(options, panelType);
+        return this.performPowerQuery(options);
       } 
       return {
         status: "error",
@@ -346,12 +345,12 @@ export class GenericDatasource {
    * @param options
    * @returns {Promise<{data: *[]}> | *}
    */
-  performPowerQuery(options, visualizationType) {
+  performPowerQuery(options) {
     const target = options.targets[0];
     const query = this.createPowerQuery(target.filter, options.range.from.valueOf(), options.range.to.valueOf(), options);
     return this.backendSrv.datasourceRequest(query).then( (response) => {
       const data = response && response.data;
-      return this.transformPowerQueryData(data, visualizationType);
+      return this.transformPowerQueryData(data);
     });
   }
 
@@ -361,10 +360,8 @@ export class GenericDatasource {
    * @returns {{data: Object[]}} transformed data that can be used by Grafana
    */
   transformPowerQueryData(data, visualizationType) {
-    if (visualizationType === this.visualizationType.TABLE) {
-      return this.transformPowerQueryDataToTable(data);
-    }
-    return GenericDatasource.transformPowerQueryDataToGraph(data);
+    return this.transformPowerQueryDataToTable(data);
+    // return GenericDatasource.transformPowerQueryDataToGraph(data);
   }
 
   /**

--- a/src/datasource.js
+++ b/src/datasource.js
@@ -361,30 +361,6 @@ export class GenericDatasource {
    */
   transformPowerQueryData(data, visualizationType) {
     return this.transformPowerQueryDataToTable(data);
-    // return GenericDatasource.transformPowerQueryDataToGraph(data);
-  }
-
-  /**
-   * Transform data returned by power query to a graph format.
-   * Each row is an individual series; this helps in looking at each value as bar in graphs.
-   * @param {*} data 
-   */
-  static transformPowerQueryDataToGraph(data) {
-    const result = [];
-    const values = data.values;
-    for (let i = 0; i < values.length; i += 1) {
-      const dataValue = values[i];
-      for (let j = 1; j < dataValue.length; j += 1) {
-        const responseObject = {
-          target: dataValue[0] + ": " + data.columns[j].name,
-          datapoints: [[dataValue[j], Date.now()]]
-        };
-        result.push(responseObject);
-      }
-    }
-    return {
-      data: result
-    };
   }
 
   /**

--- a/src/specs/datasource.test.js
+++ b/src/specs/datasource.test.js
@@ -138,14 +138,6 @@ describe('Scalyr datasource tests', () => {
       expect(resultEntry.rows.every(x => x.length === 3)).toBeTruthy();
       expect(resultEntry.rows.some(x => x[0] === 'r12')).toBeTruthy();
     });
-
-    it('Should transform power query results to graph series', () => {
-      const transformedResults = GenericDatasource.transformPowerQueryDataToGraph(results).data;
-      expect(transformedResults.length).toBe(26);
-      expect(transformedResults.some(x => x.target === 'r1: col2')).toBeTruthy();
-      expect(transformedResults.some(x => x.target === 'r1: col3')).toBeTruthy();
-      expect(transformedResults.every(x => x.datapoints.length === 1)).toBeTruthy();
-    });
   });
 
   describe('Annotation queries', () => {


### PR DESCRIPTION
At some point the "panel type" field our plugin used to determine how to format PQ data was removed. There seems to now be a single format that should work for both table and graph representations.
This PR does not do the work to make the graph representation correct, and in fact makes it more broken than before.

There will be another PR to cover CT-485 that should restore graph functionality, more or less we need to map `timestamp` values to the `time` column and translate them to the format Grafana expects.