### PR TITLE
Minor DataSetClient.doPingRequest fix and Grafana dependency update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.0.3
+
+Minor client fix and set Grafana dependency to &lt;=8.3.0.
+
 ## 3.0.2
 
 Minor changes based on Grafana support feedback.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 3.0.3
 
-Minor client fix and set Grafana dependency to &lt;=8.3.0.
+Minor client fix and set Grafana dependency to &gt;=8.3.0.
 
 ## 3.0.2
 

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -43,11 +43,11 @@
         "path": "img/DatasetConfig.png"
       }
     ],
-    "version": "3.0.2",
-    "updated": "2022-05-06"
+    "version": "3.0.3",
+    "updated": "2022-05-17"
   },
   "dependencies": {
-    "grafanaDependency": ">=7.0.0",
+    "grafanaDependency": ">=8.3.0",
     "plugins": []
   }
 }


### PR DESCRIPTION
- pkg/plugin/client.go
   - DataSetClient.doPingRequest: Minor change to always check steps completed
   - Renamed responseBody / responseBytes to respBody / respBytes (for consistency)
-  src/plugin.json
   - Updated grafanaDependency based on Grafana support feedback
