### PR TITLE
Support breakdown graphs with empty standard queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Minor README.md fixes
 - Minor default server url fix
+- Support breakdown graphs with empty standard queries
 
 ## 3.0.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Minor README.md fixes
 - Minor default server url fix
 - Support breakdown graphs with empty standard queries
+- Removed an unnecessary hardcoded field in top-facet requests
 
 ## 3.0.3
 

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -107,31 +107,17 @@ func (d *DataSetDatasource) query(_ context.Context, pCtx backend.PluginContext,
 			},
 		}
 	} else {
-		if len(qm.Expression) > 0 {
-			request = LRQRequest{
-				QueryType: PLOT,
-				StartTime: query.TimeRange.From.Unix(),
-				EndTime:   query.TimeRange.To.Unix(),
-				Plot: &PlotOptions{
-					Expression:     qm.Expression,
-					Slices:         buckets,
-					Frequency:      HIGH,
-					AutoAlign:      true,
-					BreakdownFacet: qm.BreakDownFacetValue,
-				},
-			}
-		} else {
-			request = LRQRequest{
-				QueryType: PLOT,
-				StartTime: query.TimeRange.From.Unix(),
-				EndTime:   query.TimeRange.To.Unix(),
-				Plot: &PlotOptions{
-					Expression: qm.Expression,
-					Slices:     buckets,
-					Frequency:  HIGH,
-					AutoAlign:  true,
-				},
-			}
+		request = LRQRequest{
+			QueryType: PLOT,
+			StartTime: query.TimeRange.From.Unix(),
+			EndTime:   query.TimeRange.To.Unix(),
+			Plot: &PlotOptions{
+				Expression:     qm.Expression,
+				Slices:         buckets,
+				Frequency:      HIGH,
+				AutoAlign:      true,
+				BreakdownFacet: qm.BreakDownFacetValue,
+			},
 		}
 	}
 

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -107,6 +107,13 @@ func (d *DataSetDatasource) query(_ context.Context, pCtx backend.PluginContext,
 			},
 		}
 	} else {
+		// The breakdown facet from the query may be null or the empty string.
+		// Avoid having the DataSet LRQ api attempt to treat the empty string as facet.
+		var breakdownFacet *string
+		if qm.BreakDownFacetValue != nil && len(*qm.BreakDownFacetValue) > 0 {
+			breakdownFacet = qm.BreakDownFacetValue
+		}
+
 		request = LRQRequest{
 			QueryType: PLOT,
 			StartTime: query.TimeRange.From.Unix(),
@@ -116,7 +123,7 @@ func (d *DataSetDatasource) query(_ context.Context, pCtx backend.PluginContext,
 				Slices:         buckets,
 				Frequency:      HIGH,
 				AutoAlign:      true,
-				BreakdownFacet: qm.BreakDownFacetValue,
+				BreakdownFacet: breakdownFacet,
 			},
 		}
 	}

--- a/pkg/plugin/resources.go
+++ b/pkg/plugin/resources.go
@@ -64,7 +64,6 @@ func (d *DataSetDatasource) CallResource(ctx context.Context, req *backend.CallR
 			TopFacet: &TopFacetOptions{
 				NumFacetsToReturn: 100,
 				DetermineNumeric:  true,
-				Filter:            "tag",
 			},
 		}
 		result, err := d.dataSetClient.DoTopFacetRequest(request)


### PR DESCRIPTION
Fix is just to include the breakdown graph facet even if the expression / query is empty

Also investigated the hardcoded filter value of tag when retrieving the top facets, not sure if it was required before but had no issues getting top facets (breakdown graphs) with it removed (set to "" in the actual request)