### PR TITLE
Github issue #36

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,12 @@
 name: CI
 on:
   push:
-    branches:
-      - master
-  pull_request:
-    branches:
-      - master
+  # FIXME Testing
+  #  branches:
+  #    - master
+  #pull_request:
+  #  branches:
+  #    - master
 jobs:
   frontend:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,11 @@
 name: CI
 on:
   push:
-  # FIXME Testing
-  #  branches:
-  #    - master
-  #pull_request:
-  #  branches:
-  #    - master
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 jobs:
   frontend:
     runs-on: ubuntu-latest
@@ -31,24 +30,6 @@ jobs:
         run: yarn install --frozen-lockfile
       - name: Build and test
         run: yarn build
-      # FIXME Testing
-      - name: Get version
-        id: version
-        run: |
-          import json
-          import re
-          version = json.load(open('dist/plugin.json'))['info']['version']
-          # Verify the other version strings match (until they can be eliminated)
-          assert version == json.load(open('package.json'))['version']
-          version2 = None
-          for line in open('pkg/plugin/client.go'):
-              match = re.search('VERSION\s*=\s*"(\d+\.\d+\.\d+)"', line)
-              if match:
-                 version2 = match.group(1)
-                 break
-          assert version == version2
-          print(f'::set-output name=version::{version}')
-        shell: python
   backend:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
           assert version == json.load(open('package.json'))['version']
           version2 = None
           for line in open('pkg/plugin/client.go'):
-              match = re.search('VERSION\s*=\s*"(\d+\.\d+\.\d+)", line)
+              match = re.search('VERSION\s*=\s*"(\d+\.\d+\.\d+)"', line)
               if match:
                  version2 = match.group(1)
                  break

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,24 @@ jobs:
         run: yarn install --frozen-lockfile
       - name: Build and test
         run: yarn build
+      # FIXME Testing
+      - name: Get version
+        id: version
+        run: |
+          import json
+          import re
+          version = json.load(open('dist/plugin.json'))['info']['version']
+          # Verify the other version strings match (until they can be eliminated)
+          assert version == json.load(open('package.json'))['version']
+          version2 = None
+          for line in open('pkg/plugin/client.go'):
+              match = re.search('VERSION\s*=\s*"(\d+\.\d+\.\d+)", line)
+              if match:
+                 version2 = match.group(1)
+                 break
+          assert version == version2
+          print(f'::set-output name=version::{version}')
+        shell: python
   backend:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,17 @@ jobs:
         id: version
         run: |
           import json
+          import re
           version = json.load(open('dist/plugin.json'))['info']['version']
+          # Verify the other version strings match (until they can be eliminated)
+          assert version == json.load(open('package.json'))['version']
+          version2 = None
+          for line in open('pkg/plugin/client.go'):
+              match = re.search('VERSION\s*=\s*"(\d+\.\d+\.\d+)", line)
+              if match:
+                 version2 = match.group(1)
+                 break
+          assert version == version2
           print(f'::set-output name=version::{version}')
         shell: python
       - name: Compare version and Github tag

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
           assert version == json.load(open('package.json'))['version']
           version2 = None
           for line in open('pkg/plugin/client.go'):
-              match = re.search('VERSION\s*=\s*"(\d+\.\d+\.\d+)", line)
+              match = re.search('VERSION\s*=\s*"(\d+\.\d+\.\d+)"', line)
               if match:
                  version2 = match.group(1)
                  break

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 3.0.5
 
 - Update yarn dependency @grafana/toolkit to 8.5.0
+- Set a custom user-agent to support tracking
 
 ## 3.0.4
 


### PR DESCRIPTION
https://github.com/scalyr/scalyr-grafana-datasource-plugin/issues/36

Ideally would not have to hardcode the version but I didn't see a way to query the plugin version using the sdk.  Anyways there is also another copy of the version in package.json (which seems to be required for Grafana 8.2.x).

To avoid problems with mismatched versions, I've also added a check in the Github action used to create releases.