### PR TITLE
Assign GITHUB_TOKEN used by GHA minimum amount of permissions needed.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     branches:
       - master
+permissions:
+  contents: read
 jobs:
   frontend:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,9 @@ on:
   push:
     tags:
       - "[0-9]+.[0-9]+.[0-9]+"
+permissions:
+  contents: read
+  contents: write  # neededed for gh-release action - https://stackoverflow.com/a/69941765
 jobs:
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR assigns GITHUB_TOKEN used by GHA workflows minimum amount of permissions needed.

Related PR with more context - https://github.com/scalyr/scalyr-agent-2/pull/902.