### PR TITLE
DSET-1386: Do not set autoAlign for plot requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.0.9
+
+- #110: Do not set autoAlign for plots to allow specification via query options
+
 ## 3.0.{6-8}
 
 - DataSet api usage improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 3.0.9
 
-- #110: Do not set autoAlign for plots to allow specification via query options
+- #110: Do not set autoAlign (formerly the default) for plots to allow specification via query options
 
 ## 3.0.{6-8}
 

--- a/README.md
+++ b/README.md
@@ -142,6 +142,6 @@ ${varname:doublequote} => "value1","value2","value3"
 The expected use of multi-value variables is for `in` queries, for example:
 
 ```bash
-$serverHost=(${host:singlequote})
+$serverHost in (${host:singlequote})
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sentinelone-dataset-datasource",
-  "version": "3.0.8",
+  "version": "3.0.9",
   "description": "Scalyr Observability Platform",
   "scripts": {
     "build": "grafana-toolkit plugin:build",

--- a/pkg/plugin/client.go
+++ b/pkg/plugin/client.go
@@ -50,7 +50,7 @@ func NewDataSetClient(dataSetUrl string, apiKey string) *DataSetClient {
 }
 
 func (d *DataSetClient) newRequest(method, url string, body io.Reader) (*http.Request, error) {
-	const VERSION = "3.0.8"
+	const VERSION = "3.0.9"
 
 	if err := d.rateLimiter.Wait(context.Background()); err != nil {
 		log.DefaultLogger.Error("error applying rate limiter", "err", err)

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -43,8 +43,8 @@
         "path": "img/DatasetConfig.png"
       }
     ],
-    "version": "3.0.8",
-    "updated": "2022-10-13"
+    "version": "3.0.9",
+    "updated": "2023-02-28"
   },
   "dependencies": {
     "grafanaDependency": ">=8.2.0",


### PR DESCRIPTION
Ref #110

For LRQ plot requests do not set autoAlign (default false) & explicitly set the slices to the number of max data points specified by the query options.  Setting autoAlign overrides the value specified by slices

@sergeysentinelone & @oleksiisentinelone Any potential problems with this change?  Capped max data points to 10k to be on the safe side

Other minor, unrelated changes:
- README.md update around use of multi-select values
- Bumped version in anticipation of another release