### PR TITLE
DSET-2220: Better handling of query options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.1.1
+
+- Bugfix around use of query options (max data points &amp; interval)
+
 ## 3.1.0
 
 - Bumped Golang version to 1.20

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sentinelone-dataset-datasource",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Scalyr Observability Platform",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -35,7 +35,7 @@ func NewDataSetDatasource(settings backend.DataSourceInstanceSettings) (instance
 }
 
 type DataSetDatasource struct {
-	dataSetClient *DataSetClient
+	dataSetClient DataSetClient
 }
 
 // Dispose here tells plugin SDK that plugin wants to clean up resources when a new instance
@@ -96,7 +96,10 @@ func (d *DataSetDatasource) query(ctx context.Context, query backend.DataQuery) 
 
 		// Setting the LRQ api's autoAlign would override the data points requested by the user (via query options).
 		// The query options support explicitly specifying data points (MaxDataPoints) or implicitly via time range and interval.
-		slices := query.MaxDataPoints
+		slices := int64(query.TimeRange.Duration() / query.Interval)
+		if slices > query.MaxDataPoints {
+			slices = query.MaxDataPoints
+		}
 		if slices > 10000 {
 			slices = 10000
 		}

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -43,8 +43,8 @@
         "path": "img/DatasetConfig.png"
       }
     ],
-    "version": "3.1.0",
-    "updated": "2023-03-22"
+    "version": "3.1.1",
+    "updated": "2023-03-31"
   },
   "dependencies": {
     "grafanaDependency": ">=8.2.0",


### PR DESCRIPTION
The actual change is in pkg/plugin/plugin.go & essentially specifies the data points (slices) as the duration / interval with overrides for max data points and a hard limit of 10k

The remaining changes are in support of tests (dataSetClientMock & DataSetClient interface) & for the upcoming release