### PR TITLE
Simplify secrets scanning workflow

### DIFF
--- a/.github/workflows/secrets-scanner.yaml
+++ b/.github/workflows/secrets-scanner.yaml
@@ -10,34 +10,28 @@ on:
     - cron: '0 4 * * *'
 
 permissions:
-  actions: write  # Needed for skip-duplicate-jobs job
   contents: read
 
 jobs:
-  # Special job which automatically cancels old runs for the same branch, prevents runs for the
-  # same file set which has already passed, etc.
-  pre_job:
-    name: Skip Duplicate Jobs Pre Job
-    runs-on: ubuntu-latest
-    outputs:
-      should_skip: ${{ steps.skip_check.outputs.should_skip }}
-    steps:
-      - id: skip_check
-        uses: fkirc/skip-duplicate-actions@12aca0a884f6137d619d6a8a09fcc3406ced5281 # v5.3.0
-        with:
-          cancel_others: 'true'
-          github_token: ${{ github.token }}
-
   TruffleHog:
     runs-on: ubuntu-latest
-    needs: pre_job
-    if: ${{ needs.pre_job.outputs.should_skip != 'true' || github.ref_name == 'main' }}
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+
+      # Special check which ensures that the clone performed above is not shallow. We need the
+      # complete git history for scanning to work correctly in all the situations. In some cases
+      # if a shallow clone is used, trufflehog won't not fail with an error, but it would simply
+      # not detect any files and that could be dangerous.
+      - name: Shallow repo check
+        run: |
+          if git rev-parse --is-shallow-repository | grep -q "true"; then
+            echo "Encountered a shallow repository, trufflehog may not work as expected!"
+            exit 1
+          fi
 
       - name: scan-pr
         uses: trufflesecurity/trufflehog@main
@@ -47,7 +41,6 @@ jobs:
           base: ${{ github.event.repository.default_branch }}
           head: HEAD
           extra_args: --debug --only-verified
-            --exclude-paths=${{ inputs.exclude-paths }}
 
       - name: scan-push
         uses: trufflesecurity/trufflehog@main


### PR DESCRIPTION
This pull request simplifies secret scanning workflow and gets rid of skip duplicate check and adds additional is shallow repo check job step.