### PR TITLE
Change default Dataset URL - remove tailing slash

### DIFF
--- a/pkg/plugin/plugin_test.go
+++ b/pkg/plugin/plugin_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestNewDataSetDatasource(t *testing.T) {
 	settings := backend.DataSourceInstanceSettings{
-		JSONData:                []byte(`{"scalyrUrl":"https://app.scalyr.com/"}`),
+		JSONData:                []byte(`{"scalyrUrl":"https://app.scalyr.com"}`),
 		DecryptedSecureJSONData: map[string]string{"apiKey": "key"},
 	}
 	if _, err := NewDataSetDatasource(settings); err != nil {

--- a/src/ConfigEditor.tsx
+++ b/src/ConfigEditor.tsx
@@ -75,7 +75,7 @@ export class ConfigEditor extends PureComponent<Props, State> {
               labelWidth={8}
               inputWidth={20}
               onChange={this.onURLChange}
-              value={jsonData.scalyrUrl || 'https://app.scalyr.com/'}
+              value={jsonData.scalyrUrl || 'https://app.scalyr.com'}
               placeholder="Scalyr server URL"
             />
           </div>


### PR DESCRIPTION
[9579](https://support.dataset.com/hc/en-us/requests/9579): 

- change default Dataset URL, not including the tailing / anymore
- Reason is that when creating new datasources in Grafana using the "[scalyr-grafana-datasource-plugin](https://github.com/scalyr/scalyr-grafana-datasource-plugin)" the health check fails, in case of a taling slash.
- old (already existing) datasources seem not affected.